### PR TITLE
UX-73 DatePicker stories

### DIFF
--- a/src/ml-date-picker.js
+++ b/src/ml-date-picker.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { DatePicker } from 'antd'
+const { RangePicker } = DatePicker
+
+const MLDatePicker = (props) => {
+  return (
+    <DatePicker {...props}>
+      {props.children}
+    </DatePicker>
+  )
+}
+
+// Typechecking for Ant Design properties
+MLDatePicker.propTypes = {
+}
+
+const MLRangePicker = (props) => {
+  return (
+    <RangePicker {...props}>
+      {props.children}
+    </RangePicker>
+  )
+}
+
+MLRangePicker.propTypes = {
+}
+
+MLDatePicker.MLRangePicker = MLRangePicker
+
+export default MLDatePicker

--- a/src/ml-date-picker.js
+++ b/src/ml-date-picker.js
@@ -3,25 +3,20 @@ import PropTypes from 'prop-types'
 import { DatePicker } from 'antd'
 const { RangePicker } = DatePicker
 
-const MLDatePicker = (props) => {
-  return (
-    <DatePicker {...props}>
-      {props.children}
-    </DatePicker>
-  )
-}
+const MLDatePicker = (props) => (
+  <DatePicker {...props}>
+    {props.children}
+  </DatePicker>
+)
 
-// Typechecking for Ant Design properties
 MLDatePicker.propTypes = {
 }
 
-const MLRangePicker = (props) => {
-  return (
-    <RangePicker {...props}>
-      {props.children}
-    </RangePicker>
-  )
-}
+const MLRangePicker = (props) => (
+  <RangePicker {...props}>
+    {props.children}
+  </RangePicker>
+)
 
 MLRangePicker.propTypes = {
 }

--- a/stories/73-DatePicker.stories.js
+++ b/stories/73-DatePicker.stories.js
@@ -1,0 +1,79 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import MLDatePicker from '../src/ml-date-picker'
+import { withKnobs, boolean, select, text } from '@storybook/addon-knobs'
+import _ from 'lodash'
+const { MLRangePicker } = MLDatePicker
+
+export default {
+  title: 'Data Entry/MLDatePicker',
+  decorators: [withKnobs],
+  parameters: {
+    info: {
+      text: 'Component description goes here'
+    }
+  }
+}
+
+const noopDateRender = (d) => <div>d.date()</div>
+const circleFirstDateRenderFn = (current) => {
+  const style = {}
+  if (current.date() === 1) {
+    style.border = '1px solid #1890ff'
+    style.borderRadius = '50%'
+  }
+  return (
+    <div className='ant-picker-cell-inner' style={style}>
+      {current.date()}
+    </div>
+  )
+}
+
+const disableOddDates = (d) => d.date() % 2 === 0
+
+export const datePicker = () => {
+  let props = {
+    mode: select('mode', {
+      time: 'time',
+      date: 'date',
+      month: 'month',
+      year: 'year',
+      decade: 'decade'
+    }, 'date'),
+    picker: select('picker', {
+      date: 'date',
+      week: 'week',
+      month: 'month',
+      year: 'year'
+    }, 'date'),
+    // locale: ('locale', default),
+    size: select('size', {
+      small: 'small',
+      middle: 'middle',
+      large: 'large'
+    }, 'small'),
+    bordered: boolean('bordered', false),
+    // style: object('style'),
+    // popupStyle: object('popupStyle'),
+    autoFocus: boolean('autoFocus', false),
+    disabled: boolean('disabled', false),
+    // dateRender: select('dateRender', {
+    //   None: noopDateRender,
+    //   'Bordered style': circleFirstDateRenderFn
+    // }, noopDateRender),
+    disabledDate: select('disabledDate', {
+      None: undefined,
+      '(d) => d.date() % 2 === 0': disableOddDates
+    }, undefined),
+    placeholder: text('placeholder', '')
+  }
+  // if (!props.dateRender) {
+  //   props = _.omit(props, 'dateRender')
+  // }
+  if (!props.disabledDate) {
+    props = _.omit(props, 'dateRender')
+  }
+  return (<MLDatePicker {...props} />)
+}
+
+export const rangePicker = () => <MLRangePicker />

--- a/stories/73-DatePicker.stories.js
+++ b/stories/73-DatePicker.stories.js
@@ -15,16 +15,16 @@ export default {
   }
 }
 
-const noopDateRender = (d) => <div>d.date()</div>
-const circleFirstDateRenderFn = (current) => {
+const noopDateRender = (d) => <div>{d.date()}</div>
+const circleFirstDateRenderFn = (d) => {
   const style = {}
-  if (current.date() === 1) {
+  if (d.date() === 1) {
     style.border = '1px solid #1890ff'
     style.borderRadius = '50%'
   }
   return (
     <div className='ant-picker-cell-inner' style={style}>
-      {current.date()}
+      {d.date()}
     </div>
   )
 }
@@ -32,7 +32,7 @@ const circleFirstDateRenderFn = (current) => {
 const disableOddDates = (d) => d.date() % 2 === 0
 
 export const datePicker = () => {
-  let props = {
+  const props = {
     mode: select('mode', {
       time: 'time',
       date: 'date',
@@ -65,13 +65,9 @@ export const datePicker = () => {
       None: undefined,
       '(d) => d.date() % 2 === 0': disableOddDates
     }, undefined),
-    placeholder: text('placeholder', '')
-  }
-  // if (!props.dateRender) {
-  //   props = _.omit(props, 'dateRender')
-  // }
-  if (!props.disabledDate) {
-    props = _.omit(props, 'dateRender')
+    placeholder: text('placeholder', ''),
+    onOpenChange: action('onOpenChange'),
+    onPanelChange: action('onPanelChange')
   }
   return (<MLDatePicker {...props} />)
 }


### PR DESCRIPTION
Knobs I skipped:
- locale requires a rather complicated translation config object
- style and popupStyle require long objects; unwieldy for a knob
- dateRender doesn't seem to work correctly if you provide it as a knob, only if you provide it directly as a function. Could do this as a second story, but this is a weird prop anyway.

I'm not sure how we want to handle propTypes, as those are already handled by Ant Design's documentation. Maybe just include them for new props we add?