### PR TITLE
UX-11 Fix rollup build, rename a story

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "gh-pages": "^2.1.1",
     "less": "^3.11.1",
     "less-loader": "^5.0.0",
-    "lodash": "^4.17.15",
+    "lodash-es": "^4.17.15",
     "node-sass": "^4.13.1",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",

--- a/src/ml-table.js
+++ b/src/ml-table.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Descriptions, Table } from 'antd'
-import { cloneDeep, isUndefined, isArray, merge } from 'lodash'
+import { cloneDeep, isUndefined, isArray, merge } from 'lodash-es'
 import './ml-table.css'
 import { DownOutlined, RightOutlined } from './ml-icon'
 

--- a/stories/11-Table.stories.js
+++ b/stories/11-Table.stories.js
@@ -23,7 +23,7 @@ export const basic = () => {
   return (<MLTable {...props} onChange={action('onChange')} />)
 }
 
-export const smartMastering = () => {
+export const embeddedTables = () => {
   const props = {
     dataSource: sampleNestedData.dataSource,
     columns: sampleNestedData.columns,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9271,6 +9271,11 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+lodash-es@^4.17.15:
+  version "4.17.15"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
+  integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"


### PR DESCRIPTION
This fixes the rollup build for lodash by using the lodash-es version. (Webpack was figuring out the import while rollup was not; I'll try to make sure I test the rollup build more in the future with changes like this).

I also renamed one story, but that commit didn't make it in before the last PR was merged.