### PR TITLE
UX-86 Make displayNames consistent and un-confusing

### DIFF
--- a/gulpfile.js/fix-uniformity-gulp.js
+++ b/gulpfile.js/fix-uniformity-gulp.js
@@ -148,23 +148,61 @@ import './index.less'
   })
 }
 
+const fixDisplayNames = () => {
+  return through.obj(function(file, enc, cb) {
+    const childComponentName = path.basename(file.path).replace('.js', '')
+    const parentComponentName = path.basename(path.dirname(file.path))
+
+    if (parentComponentName === childComponentName) {
+      return cb(null, file)
+    }
+
+    const pattern = RegExp(`${childComponentName}.displayName = (.*?)\n`, 'g')
+
+    const code = file.contents.toString()
+    const matches = [...code.matchAll(pattern)]
+
+    const correctedDisplayNameLine = `${childComponentName}.displayName = '${parentComponentName}.${childComponentName}'\n`
+
+    if (matches.length === 0) {
+      // Insert it before the export line
+      const exportPattern = RegExp(`(?<exportLine>export default ${childComponentName})`)
+      const newCode = code.replace(exportPattern, (
+`${correctedDisplayNameLine}
+$<exportLine>`
+      ))
+      file.contents = Buffer.from(newCode)
+    } else if (matches.length === 1) {
+      //  Modify the existing line
+      const newCode = code.replace(pattern, correctedDisplayNameLine)
+      file.contents = Buffer.from(newCode)
+    } else {
+      console.warn(`${parentComponentName}.${childComponentName} has multiple displayName lines; can't fix automatically.`)
+    }
+
+    cb(null, file)
+  })
+}
+
 const fixUniformityTask = gulp.task('fix-uniformity', gulp.series(
-  () => {
+  function fixCustomUniformityRules() {
     const src = gulp.src(path.resolve(__dirname, '../src/ML*/ML*.js'))
     return merge(
       src
         .pipe(checkMultipleComponentsOneFile())
         .pipe(removeImport(/import '\.\/style'\n/))
         .pipe(ensureImport("import classNames from 'classnames'"))
-        .pipe(addClassNames()),
+        .pipe(addClassNames())
+        .pipe(fixDisplayNames()),
       src
         .pipe(ensureStyleFolder()),
     )
       .pipe(gulp.dest(path.resolve(__dirname, '../src')))
   },
-  () => {
+  function fixESLintProblems() {
     return gulp.src(path.resolve(__dirname, '../src/**/*.js'))
       .pipe(eslint({ fix: true }))
+      // .pipe(eslint.format()) // Enable later once the output is less
       .pipe(gulp.dest(path.resolve(__dirname, '../src')))
   },
 ))

--- a/src/MLBreadcrumb/MLItem.js
+++ b/src/MLBreadcrumb/MLItem.js
@@ -15,4 +15,6 @@ const MLItem = (props) => {
   )
 }
 
+MLItem.displayName = 'MLBreadcrumb.MLItem'
+
 export default MLItem

--- a/src/MLCollapse/MLPanel.js
+++ b/src/MLCollapse/MLPanel.js
@@ -14,4 +14,6 @@ const MLPanel = (props) => {
   )
 }
 
+MLPanel.displayName = 'MLCollapse.MLPanel'
+
 export default MLPanel

--- a/src/MLDatePicker/MLRangePicker.js
+++ b/src/MLDatePicker/MLRangePicker.js
@@ -42,4 +42,6 @@ MLRangePicker.propTypes = {
   size: PropTypes.string,
 }
 
+MLRangePicker.displayName = 'MLDatePicker.MLRangePicker'
+
 export default MLRangePicker

--- a/src/MLLayout/MLContent.js
+++ b/src/MLLayout/MLContent.js
@@ -19,4 +19,6 @@ const MLContent = (props) => {
   )
 }
 
+MLContent.displayName = 'MLLayout.MLContent'
+
 export default MLContent

--- a/src/MLLayout/MLFooter.js
+++ b/src/MLLayout/MLFooter.js
@@ -61,4 +61,6 @@ MLFooter.propTypes = {
   graphicBackground: PropTypes.bool,
 }
 
+MLFooter.displayName = 'MLLayout.MLFooter'
+
 export default MLFooter

--- a/src/MLLayout/MLHeader.js
+++ b/src/MLLayout/MLHeader.js
@@ -28,4 +28,6 @@ const MLHeader = (props) => {
   )
 }
 
+MLHeader.displayName = 'MLLayout.MLHeader'
+
 export default MLHeader

--- a/src/MLLayout/MLSider.js
+++ b/src/MLLayout/MLSider.js
@@ -29,4 +29,6 @@ const MLSider = (props) => {
   )
 }
 
+MLSider.displayName = 'MLLayout.MLSider'
+
 export default MLSider

--- a/src/MLMentions/MLOption.js
+++ b/src/MLMentions/MLOption.js
@@ -14,4 +14,6 @@ const MLOption = (props) => {
   )
 }
 
+MLOption.displayName = 'MLMentions.MLOption'
+
 export default MLOption

--- a/src/MLRadio/MLButton.js
+++ b/src/MLRadio/MLButton.js
@@ -14,4 +14,6 @@ const MLButton = (props) => (
 
 MLButton.propTypes = {}
 
+MLButton.displayName = 'MLRadio.MLButton'
+
 export default MLButton

--- a/src/MLRadio/MLGroup.js
+++ b/src/MLRadio/MLGroup.js
@@ -16,7 +16,7 @@ MLGroup.defaultProps = {
   size: 'small',
 }
 
-MLGroup.displayName = 'MLRadioGroup'
+MLGroup.displayName = 'MLRadio.MLGroup'
 
 MLGroup.propTypes = {}
 

--- a/src/MLSelect/MLOptGroup.js
+++ b/src/MLSelect/MLOptGroup.js
@@ -9,4 +9,6 @@ class MLOptGroup extends OptGroup {}
 MLOptGroup.defaultProps = {}
 MLOptGroup.propTypes = {}
 
+MLOptGroup.displayName = 'MLSelect.MLOptGroup'
+
 export default MLOptGroup

--- a/src/MLSelect/MLOption.js
+++ b/src/MLSelect/MLOption.js
@@ -9,4 +9,6 @@ class MLOption extends Option {}
 MLOption.defaultProps = {}
 MLOption.propTypes = {}
 
+MLOption.displayName = 'MLSelect.MLOption'
+
 export default MLOption

--- a/src/MLTag/MLCheckableTag.js
+++ b/src/MLTag/MLCheckableTag.js
@@ -14,4 +14,6 @@ const MLCheckableTag = (props) => {
   )
 }
 
+MLCheckableTag.displayName = 'MLTag.MLCheckableTag'
+
 export default MLCheckableTag


### PR DESCRIPTION
Any other unmerged branches (in particular, MLInput's) will need to have the `fix-uniformity` gulp task run on them before they're merged.