### PR TITLE
UX-123 Fix Table perf issues for large column prop

### DIFF
--- a/src/MLTable/MLTable.js
+++ b/src/MLTable/MLTable.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Descriptions, Table } from 'antd'
-import { cloneDeep, merge } from 'lodash-es'
+import { clone, merge } from 'lodash-es'
 import { DownOutlined, RightOutlined } from '../MLIcon'
 import classNames from 'classnames'
 
@@ -82,7 +82,7 @@ class MLTable extends React.Component {
       return <MLHeaderTable columns={columns} />
     }
     const restructuredColumns = columns.map((originalColumn) => {
-      const restructuredColumn = cloneDeep(originalColumn)
+      const restructuredColumn = clone(originalColumn)
       if (originalColumn.columns !== undefined) {
         if (originalColumn.dataIndex === undefined) {
           throw Error('dataIndex must be specified when nesting columns')


### PR DESCRIPTION
This fixes a performance issue MLTable would have if the passed-in columns prop was a very large object, by using `clone` instead of `cloneDeep`, to create a shallow clone (which is dramatically faster).