### PR TITLE
UX-74 Layout.Footer

### DIFF
--- a/src/MLLayout/MLContent.js
+++ b/src/MLLayout/MLContent.js
@@ -5,12 +5,9 @@ import classNames from 'classnames'
 
 const { Content } = Layout
 
-const contentStyle = {}
-
 const MLContent = (props) => {
   return (
     <Content
-      style={contentStyle}
       {...props}
       className={classNames('ml-layout-content', props.className)}
     >

--- a/src/MLLayout/MLFooter.js
+++ b/src/MLLayout/MLFooter.js
@@ -5,60 +5,15 @@ import classNames from 'classnames'
 
 const { Footer } = Layout
 
-const footerStyleBase = {
-  padding: '12px 50px',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  flexDirection: 'column',
-  width: '100%',
-  textAlign: 'center',
-  margin: '0',
-  fontSize: '14px',
-  fontFamily: 'Helvetica Neue',
-}
-
-const footerStyleWhiteBg = Object.assign({}, footerStyleBase, {
-  color: '#999',
-  backgroundColor: '#fff',
-})
-
-const footerStyleGraphicBg = Object.assign({}, footerStyleBase, {
-  color: '#fff',
-  background: 'unset',
-})
-
-const footerSpanStyle = {
-  padding: '0 5px',
-}
-
 const MLFooter = (props) => {
-  const footerStyle = props.graphicBackground ? footerStyleGraphicBg : footerStyleWhiteBg
   return (
     <Footer
-      style={footerStyle}
       {...props}
       className={classNames('ml-layout-footer', props.className)}
     >
-      <div>
-        <span style={footerSpanStyle}>Copyright @ {props.year} MarkLogic Corporation. All Rights Reserved.</span>
-        |
-        <span style={footerSpanStyle}>
-          <a href='#TODO'>Terms and Conditions</a>
-        </span>
-        |
-        <span style={footerSpanStyle}>
-          <a href='#TODO'>Policies</a>
-        </span>
-      </div>
+      {props.children}
     </Footer>
   )
-}
-
-// Typechecking for Ant Design properties
-MLFooter.propTypes = {
-  year: PropTypes.number,
-  graphicBackground: PropTypes.bool,
 }
 
 MLFooter.displayName = 'MLLayout.MLFooter'

--- a/src/MLLayout/MLHeader.js
+++ b/src/MLLayout/MLHeader.js
@@ -5,21 +5,9 @@ import classNames from 'classnames'
 
 const { Header } = Layout
 
-const headerStyle = {
-  backgroundColor: '#c4c4c4',
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  textAlign: 'center',
-  height: '64px',
-  // fontSize: 'TODO',
-  // fontFamily: 'TODO',
-}
-
 const MLHeader = (props) => {
   return (
     <Header
-      style={headerStyle}
       {...props}
       className={classNames('ml-layout-header', props.className)}
     >

--- a/src/MLLayout/MLLayout.js
+++ b/src/MLLayout/MLLayout.js
@@ -3,12 +3,9 @@ import PropTypes from 'prop-types'
 import { Layout } from 'antd'
 import classNames from 'classnames'
 
-const layoutStyle = {}
-
 export const MLLayout = (props) => {
   return (
     <Layout
-      style={layoutStyle}
       {...props}
       className={classNames('ml-layout', props.className)}
     >

--- a/src/MLLayout/MLSider.js
+++ b/src/MLLayout/MLSider.js
@@ -4,23 +4,9 @@ import { Layout } from 'antd'
 import classNames from 'classnames'
 const { Sider } = Layout
 
-const siderStyle = {
-  display: 'flex',
-  flexDirection: 'column',
-  alignItems: 'center',
-  justifyContent: 'center',
-  backgroundColor: '#dddddd',
-}
-
-const siderProps = {
-  width: 70,
-}
-
 const MLSider = (props) => {
   return (
     <Sider
-      style={siderStyle}
-      {...siderProps}
       {...props}
       className={classNames('ml-layout-sider', props.className)}
     >

--- a/src/MLLayout/style/index.less
+++ b/src/MLLayout/style/index.less
@@ -1,1 +1,6 @@
 @import '../../styles.less';
+
+.ml-layout-footer {
+  text-align: center;
+  font-size: 14px;
+}

--- a/stories/75-Layout.stories.js
+++ b/stories/75-Layout.stories.js
@@ -14,20 +14,70 @@ export default {
   },
 }
 
+const footerStyleBase = {
+  padding: '12px 50px',
+}
+const footerStyleWhiteBg = Object.assign({}, footerStyleBase, {
+  color: '#999',
+  backgroundColor: '#fff',
+})
+
+const footerStyleGraphicBg = Object.assign({}, footerStyleBase, {
+  color: '#fff',
+  background: 'unset',
+})
+
+const footerSpanStyle = {
+  padding: '0 5px',
+}
+
+const year = 2020
+
+const siderStyle = {
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'center',
+  justifyContent: 'center',
+  backgroundColor: '#dddddd',
+}
+
+const headerStyle = {
+  backgroundColor: '#c4c4c4',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  textAlign: 'center',
+  height: '64px',
+}
+
 export const dataHubLayout = (props) => {
   const graphicBackground = boolean('graphicBackground', true)
   const layoutStyle = graphicBackground ? { backgroundImage: 'linear-gradient(to right, #af474a, #73263b)' } : null
+  const footerStyle = graphicBackground ? footerStyleGraphicBg : footerStyleWhiteBg
   return (
     <div>
       <div>Note: On the hosted (non-local) StoryBook, this component's custom CSS is not currently rendering correctly. This should not affect use of the component in your app.</div>
       <MLLayout>
-        <MLHeader>Header</MLHeader>
+        <MLHeader style={headerStyle}>Header</MLHeader>
         <MLLayout>
           <MLLayout style={layoutStyle}>
             <MLContent style={{ height: '300px' }}>Content</MLContent>
-            <MLFooter graphicBackground={graphicBackground} year={2019}>Footer</MLFooter>
+            <MLFooter
+              style={footerStyle}
+              year={year}
+            >
+              <span style={footerSpanStyle}>Copyright @ {year} MarkLogic Corporation. All Rights Reserved.</span>
+              |
+              <span style={footerSpanStyle}>
+                <a href='#TODO'>Terms and Conditions</a>
+              </span>
+              |
+              <span style={footerSpanStyle}>
+                <a href='#TODO'>Policies</a>
+              </span>
+            </MLFooter>
           </MLLayout>
-          <MLSider>Sider</MLSider>
+          <MLSider style={siderStyle} width={70}>Sider</MLSider>
         </MLLayout>
       </MLLayout>
     </div>
@@ -37,13 +87,27 @@ export const dataHubLayout = (props) => {
 export const generalLayout = (props) => {
   const graphicBackground = boolean('graphicBackground', true)
   const layoutStyle = graphicBackground ? { backgroundImage: 'linear-gradient(to right, #af474a, #73263b)' } : null
+  const footerStyle = graphicBackground ? footerStyleGraphicBg : footerStyleWhiteBg
   return (
     <div>
       <div>Note: On the hosted (non-local) StoryBook, this component's custom CSS is not currently rendering correctly. This should not affect use of the component in your app.</div>
       <MLLayout style={layoutStyle}>
-        <MLHeader>Header</MLHeader>
+        <MLHeader style={headerStyle}>Header</MLHeader>
         <MLContent style={{ height: '300px' }}>Content</MLContent>
-        <MLFooter graphicBackground={graphicBackground} year={2019}>Footer</MLFooter>
+        <MLFooter
+          style={footerStyle}
+          year={year}
+        >
+          <span style={footerSpanStyle}>Copyright @ {year} MarkLogic Corporation. All Rights Reserved.</span>
+          |
+          <span style={footerSpanStyle}>
+            <a href='#TODO'>Terms and Conditions</a>
+          </span>
+          |
+          <span style={footerSpanStyle}>
+            <a href='#TODO'>Policies</a>
+          </span>
+        </MLFooter>
       </MLLayout>
     </div>
   )


### PR DESCRIPTION
This generalizes the Layout.Footer component instead of baking things into it, and moves the custom styling and content to a story. Same treatment for the styling of the other Layout components.

EDIT: whoops, numbered this wrong initially. This is for UX-74. Branch is accidentally named 75.