### PR TITLE
UX-54 Popover

### DIFF
--- a/playground/src/App.js
+++ b/playground/src/App.js
@@ -8,6 +8,7 @@ import {
   MLLayout,
   MLSlider,
   MLConfigProvider,
+  MLPopover,
 } from '@marklogic/design-system'
 
 import {
@@ -84,6 +85,25 @@ export default class App extends Component {
               <MLDatePicker size='default' />
               <MLDatePicker size='large' />
               <MLDatePicker picker='week' />
+              <div style={{ height: 100 }}>Some short content</div>
+              <MLPopover
+                arrowPointAtCenter
+                content={<div><p>Content</p><p>Content</p></div>}
+                placement='top'
+                title='Title'
+                trigger={[
+                  'hover',
+                  'focus',
+                ]}
+              >
+                <MLButton
+                  style={{ marginLeft: '100px' }}
+                  size='small'
+                  type='primary'
+                >
+                  Hover me
+                </MLButton>
+              </MLPopover>
               <div style={{ height: 2000 }}>Some tall content</div>
             </MLLayout.MLContent>
             <MLLayout.MLFooter year='2019' />

--- a/src/MLPopconfirm/MLPopconfirm.js
+++ b/src/MLPopconfirm/MLPopconfirm.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Popconfirm } from 'antd'
 import classNames from 'classnames'
+import { AbstractTooltipProps } from '../MLTooltip'
 
 const MLPopconfirm = (props) => {
   return (
@@ -13,5 +14,28 @@ const MLPopconfirm = (props) => {
     </Popconfirm>
   )
 }
+
+MLPopconfirm.defaultProps = {
+}
+
+MLPopconfirm.propTypes = Object.assign({
+  /** text of the Cancel button */
+  cancelText: PropTypes.string,
+  /** text of the Confirm button */
+  okText: PropTypes.string,
+  /** Button type of the Confirm button */
+  okType: PropTypes.string,
+  /** title of the confirmation box */
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** callback of cancel */
+  onCancel: PropTypes.func,
+  /** callback of confirmation */
+  onConfirm: PropTypes.func,
+  /** customize icon of confirmation */
+  icon: PropTypes.node,
+  /** is show popconfirm when click its childrenNode */
+  disabled: PropTypes.bool,
+
+}, AbstractTooltipProps)
 
 export default MLPopconfirm

--- a/src/MLPopover/MLPopover.js
+++ b/src/MLPopover/MLPopover.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Popover } from 'antd'
+import PropTypes from 'prop-types'
+import classNames from 'classnames'
+import { AbstractTooltipProps } from '../MLTooltip'
+
+const MLPopover = (props) => {
+  return (
+    <Popover
+      {...props}
+      className={classNames('ml-popover', props.className)}
+    >
+      {props.children}
+    </Popover>
+  )
+}
+
+MLPopover.defaultProps = {
+  trigger: ['hover', 'focus'],
+  placement: 'top',
+}
+
+MLPopover.propTypes = Object.assign({
+  /** Content of the card */
+  content: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  /** Title of the card */
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+}, AbstractTooltipProps)
+
+export default MLPopover

--- a/src/MLPopover/index.js
+++ b/src/MLPopover/index.js
@@ -1,0 +1,3 @@
+import MLPopover from './MLPopover'
+
+export default MLPopover

--- a/src/MLPopover/style/index.js
+++ b/src/MLPopover/style/index.js
@@ -1,0 +1,2 @@
+import 'antd/es/popover/style'
+import './index.less'

--- a/src/MLTooltip/MLTooltip.js
+++ b/src/MLTooltip/MLTooltip.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Tooltip } from 'antd'
 import classNames from 'classnames'
+import { AbstractTooltipProps } from './index'
 
 const MLTooltip = (props) => {
   return (
@@ -14,5 +15,13 @@ const MLTooltip = (props) => {
     </Tooltip>
   )
 }
+
+MLTooltip.defaultProps = {
+}
+
+MLTooltip.propTypes = Object.assign({
+  /** Title of the card */
+  title: PropTypes.oneOfType([PropTypes.string, PropTypes.node, PropTypes.func]),
+}, AbstractTooltipProps)
 
 export default MLTooltip

--- a/src/MLTooltip/index.js
+++ b/src/MLTooltip/index.js
@@ -1,2 +1,33 @@
 import MLTooltip from './MLTooltip'
+import PropTypes from 'prop-types'
+
+export const AbstractTooltipProps = {
+  /** Whether the arrow is pointed at the center of target */
+  arrowPointAtCenter: PropTypes.bool,
+  /** Whether to adjust popup placement automatically when popup is off screen */
+  autoAdjustOverflow: PropTypes.bool,
+  /** Whether the floating tooltip card is visible by default */
+  defaultVisible: PropTypes.bool,
+  /** The DOM container of the tip, the default behavior is to create a div element in body */
+  getPopupContainer: PropTypes.func,
+  /** Delay in seconds, before tooltip is shown on mouse enter */
+  mouseEnterDelay: PropTypes.number,
+  /** Delay in seconds, before tooltip is hidden on mouse leave */
+  mouseLeaveDelay: PropTypes.number,
+  /** Class name of the tooltip card */
+  overlayClassName: PropTypes.string,
+  /** Style of the tooltip card */
+  overlayStyle: PropTypes.object,
+  /** The position of the tooltip relative to the target, which can be one of top left right bottom topLeft topRight bottomLeft bottomRight leftTop leftBottom rightTop rightBottom */
+  placement: PropTypes.string,
+  /** Tooltip trigger mode. Could be multiple by passing an array */
+  trigger: PropTypes.oneOfType([PropTypes.oneOf(['hover', 'focus', 'click', 'contextMenu']), PropTypes.arrayOf(PropTypes.string)]),
+  /** Whether the floating tooltip card is visible or not */
+  visible: PropTypes.bool,
+  /** Callback executed when visibility of the tooltip card is changed */
+  onVisibleChange: PropTypes.func,
+  /** this value will be merged into placement's config, please refer to the settings rc-tooltip */
+  align: PropTypes.object,
+}
+
 export default MLTooltip

--- a/stories/54-Popover.less
+++ b/stories/54-Popover.less
@@ -1,0 +1,5 @@
+.popover-story-demo-container {
+  width: 100%;
+  display: flex;
+  justify-content: space-around;
+}

--- a/stories/54-Popover.stories.js
+++ b/stories/54-Popover.stories.js
@@ -1,7 +1,8 @@
 import React from 'react'
 import { action } from '@storybook/addon-actions'
-import {boolean, radios, withKnobs} from "@storybook/addon-knobs";
+import { boolean, radios, withKnobs } from '@storybook/addon-knobs'
 import { MLPopover, MLButton } from '@marklogic/design-system'
+import './54-Popover.less'
 
 export default {
   title: 'Data Display/MLPopover',
@@ -35,14 +36,16 @@ export const basic = () => {
     </div>
   )
   return (
-    <MLPopover
-      content={content}
-      title='Title'
-      placement={placement}
-      arrowPointAtCenter={boolean('arrowPointAtCenter', false)}
+    <div className='popover-story-demo-container'>
+      <MLPopover
+        content={content}
+        title='Title'
+        placement={placement}
+        arrowPointAtCenter={boolean('arrowPointAtCenter', false)}
       // okText={text('okText', 'OK')}
-    >
-      <MLButton type='primary'>Hover me</MLButton>
-    </MLPopover>
+      >
+        <MLButton type='primary'>Hover me</MLButton>
+      </MLPopover>
+    </div>
   )
 }

--- a/stories/54-Popover.stories.js
+++ b/stories/54-Popover.stories.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import { action } from '@storybook/addon-actions'
+import {boolean, radios, withKnobs} from "@storybook/addon-knobs";
+import { MLPopover, MLButton } from '@marklogic/design-system'
+
+export default {
+  title: 'Data Display/MLPopover',
+  decorators: [withKnobs],
+  parameters: {
+    info: {
+      text: 'Component description goes here',
+    },
+  },
+}
+
+export const basic = () => {
+  const placement = radios('placement', [
+    'topLeft',
+    'top',
+    'topRight',
+    'leftTop',
+    'left',
+    'leftBottom',
+    'rightTop',
+    'right',
+    'rightBottom',
+    'bottomLeft',
+    'bottom',
+    'bottomRight',
+  ], 'top')
+  const content = (
+    <div>
+      <p>Content</p>
+      <p>Content</p>
+    </div>
+  )
+  return (
+    <MLPopover
+      content={content}
+      title='Title'
+      placement={placement}
+      arrowPointAtCenter={boolean('arrowPointAtCenter', false)}
+      // okText={text('okText', 'OK')}
+    >
+      <MLButton type='primary'>Hover me</MLButton>
+    </MLPopover>
+  )
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12929,14 +12929,6 @@ raw-loader@^3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-raw-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.1.tgz#14e1f726a359b68437e183d5a5b7d33a3eba6933"
-  integrity sha512-baolhQBSi3iNh1cglJjA0mYzga+wePk7vdEX//1dTFd+v4TsQlQE0jitJSNF1OIP82rdYulH7otaVmdlDaJ64A==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^2.6.5"
-
 rc-align@^2.4.0, rc-align@^2.4.1:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-2.4.5.tgz#c941a586f59d1017f23a428f0b468663fb7102ab"


### PR DESCRIPTION
This adds the Popover component.
As part of adding its propTypes, I added propTypes to Tooltip and PopConfirm as well, similar to how Ant does it on their end.