### PR TITLE
UX-10 Fix EditableSlider use of propTypes in production

### DIFF
--- a/src/MLEditableSlider/MLEditableSlider.js
+++ b/src/MLEditableSlider/MLEditableSlider.js
@@ -15,12 +15,12 @@ const MLEditableSlider = (props) => {
   )
 
   const sliderProps = Object.assign(
-    pick(props, Object.keys(MLSlider.propTypes)),
+    pick(props, MLSlider.propKeys),
     props.sliderProps,
   )
 
   const inputNumberProps = Object.assign(
-    pick(props, Object.keys(MLInputNumber.propTypes)),
+    pick(props, MLInputNumber.propKeys),
     props.inputNumberProps,
   )
 

--- a/src/MLInputNumber/MLInputNumber.js
+++ b/src/MLInputNumber/MLInputNumber.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { InputNumber } from 'antd'
 import MLSizeContext from '../MLConfigProvider/MLSizeContext'
 import classNames from 'classnames'
-import MLSlider from "../MLSlider";
+import MLSlider from '../MLSlider'
 
 const MLInputNumber = (props) => {
   return (
@@ -23,6 +23,24 @@ const MLInputNumber = (props) => {
     </MLSizeContext.Consumer>
   )
 }
+
+// propTypes is removed in production automatically, so we need to list them here for runtime use in MLEditableSlider
+MLInputNumber.propKeys = [
+  'autoFocus',
+  'defaultValue',
+  'disabled',
+  'formatter',
+  'max',
+  'min',
+  'parser',
+  'precision',
+  'decimalSeparator',
+  'size',
+  'step',
+  'value',
+  'onChange',
+  'onPressEnter',
+]
 
 MLInputNumber.propTypes = {
   autoFocus: PropTypes.bool,

--- a/src/MLSlider/MLSlider.js
+++ b/src/MLSlider/MLSlider.js
@@ -18,6 +18,29 @@ MLSlider.defaultProps = {
   tooltipVisible: undefined,
 }
 
+// propTypes is removed in production automatically, so we need to list them here for runtime use in MLEditableSlider
+MLSlider.propKeys = [
+  'autoFocus',
+  'defaultValue',
+  'disabled',
+  'dots',
+  'included',
+  'marks',
+  'max',
+  'min',
+  'range',
+  'reverse',
+  'step',
+  'tipFormatter',
+  'value',
+  'vertical',
+  'onAfterChange',
+  'onChange',
+  'tooltipPlacement',
+  'tooltipVisible',
+  'getTooltipPopupContainer',
+]
+
 MLSlider.propTypes = {
   autoFocus: PropTypes.bool,
   defaultValue: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),

--- a/yarn.lock
+++ b/yarn.lock
@@ -12929,14 +12929,6 @@ raw-loader@^3.1.0:
     loader-utils "^1.1.0"
     schema-utils "^2.0.1"
 
-raw-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/raw-loader/-/raw-loader-4.0.1.tgz#14e1f726a359b68437e183d5a5b7d33a3eba6933"
-  integrity sha512-baolhQBSi3iNh1cglJjA0mYzga+wePk7vdEX//1dTFd+v4TsQlQE0jitJSNF1OIP82rdYulH7otaVmdlDaJ64A==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^2.6.5"
-
 rc-align@^2.4.0, rc-align@^2.4.1:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/rc-align/-/rc-align-2.4.5.tgz#c941a586f59d1017f23a428f0b468663fb7102ab"


### PR DESCRIPTION
Turns out create-react-app removes all propTypes in production; this works around that.