### PR TITLE
UX-25 Increase movable area of draggable Modal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ storybook-dist
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+.idea
+playground/report*.json

--- a/src/MLModal/MLModal.js
+++ b/src/MLModal/MLModal.js
@@ -5,6 +5,7 @@ import classNames from 'classnames'
 const MLModal = (props) => {
   return (
     <DraggableModal
+      initialHeight={0}
       {...props}
       className={classNames('ml-modal', props.className)}
     >

--- a/stories/25-Modal.stories.js
+++ b/stories/25-Modal.stories.js
@@ -40,7 +40,11 @@ export const Basic = () => {
         okType={text('okType', 'primary')}
       >
         <h3>Contents</h3>
-        <div>Your text here.</div>
+        <div>
+          Your text here.<br />
+          Your text here.<br />
+          Your text here.<br />
+        </div>
       </MLModal>
     </MLModal.MLDraggableModalProvider>
   )


### PR DESCRIPTION
Previously, the modal could not be moved near the bottom of the screen because it had a too-tall HTML height. I now set that height to zero. This does mean that the bottom of the modal can go off the screen; if you want it not to, you have to set `initialHeight` yourself to a correct value.
