### PR TITLE
UX-121 add config provider note

### DIFF
--- a/stories/67-ConfigProvider.mdx
+++ b/stories/67-ConfigProvider.mdx
@@ -6,8 +6,7 @@ import MLConfigProvider from '../src/MLConfigProvider';
 
 [Ant Documentation](https://3x.ant.design/components/config-provider)
 
-There's nothing here yet.
-
+Note that the MLConfigProvider should be supplied near the top of the application tree structure, such that all ML components are descendants of it. Config values from MLConfigProvider will be provided automatically through the [React Context API](https://reactjs.org/docs/context.htmlhttps://reactjs.org/docs/context.html).
 
 <PropsPanels of={[
   MLConfigProvider,

--- a/stories/67-ConfigProvider.stories.jsx
+++ b/stories/67-ConfigProvider.stories.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { action } from '@storybook/addon-actions'
 import { MLConfigProvider, MLDatePicker } from '@marklogic/design-system'
-import { withKnobs } from '@storybook/addon-knobs'
+import { withKnobs, text } from '@storybook/addon-knobs'
 import mdx from './67-ConfigProvider.mdx'
 
 export default {
@@ -30,13 +30,12 @@ export const basic = () => {
   return (
     <div>
       <div>This component doesn't seem to allow updates in Storybook, so here are some static examples:</div>
-      <div>TODO: Consider using this for global settings that are spec'd in the tickets</div>
       <br />
-      <div>Near the top of the tree of your application (such that all @marklogic/design-system components are descendants of this), you must provide a MLConfigProvider like so:</div>
+      <div>Near the top of the tree of your application (such that all @marklogic/design-system components are descendants of this), you must provide a MLConfigProvider like so (see the story source below):</div>
       <MLConfigProvider {...configValues}>
-        (application components go here)
+        <div>(application components go here)</div>
         <MLDatePicker />
-        ...etc
+        <div>...etc</div>
       </MLConfigProvider>
     </div>
   )

--- a/stories/73-DatePicker.mdx
+++ b/stories/73-DatePicker.mdx
@@ -21,6 +21,10 @@ There's nothing here yet.
 
 There's nothing here yet.
 
+# MLConfigProvider
+
+See the docs page for [MLConfigProvider](/?path=/docs/other-mlconfigprovider--basic)
+
 <PropsPanels of={[
   MLDatePicker,
   MLDatePicker.MLMonthPicker,

--- a/stories/73-DatePicker.stories.jsx
+++ b/stories/73-DatePicker.stories.jsx
@@ -38,7 +38,6 @@ export const datePicker = () => {
       middle: 'middle',
       large: 'large',
     }, 'small'),
-    bordered: boolean('bordered', true),
     autoFocus: boolean('autoFocus', false),
     disabled: boolean('disabled', false),
     disabledDate: select('disabledDate', {
@@ -70,7 +69,6 @@ export const rangePicker = () => {
       middle: 'middle',
       large: 'large',
     }, 'small'),
-    bordered: boolean('bordered', true),
     autoFocus: boolean('autoFocus', false),
     disabled: boolean('disabled', false),
     disabledDate: select('disabledDate', {


### PR DESCRIPTION
This also removes the 'bordered' knob from DatePicker, which doesn't have that prop in Ant v3.