### PR TITLE
UX-148 Include Descriptions CSS in MLTable

### DIFF
--- a/src/MLTable/style/index.js
+++ b/src/MLTable/style/index.js
@@ -1,3 +1,4 @@
 import 'antd/es/table/style'
+import 'antd/es/descriptions/style'
 import '../../MLIcon/style'
 import './index.less'


### PR DESCRIPTION
MLTable was erroneously missing the CSS from Ant's Descriptions component, which is used in MLHeaderTable (for collapsed sub-tables)