### PR TITLE
Jamie fong patch 1

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -14,3 +14,13 @@ if (process.env.NODE_ENV !== 'test') {
     })
   );
 }
+
+// Sort in alphabetical order, with Welcome page first
+export const parameters = {
+  options: {
+    storySort: {
+      method: 'alphabetical',
+      order: ['Welcome', 'Components'], 
+    },
+  },
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -15,12 +15,12 @@ if (process.env.NODE_ENV !== 'test') {
   );
 }
 
-// Sort in alphabetical order, with Welcome page first
+// Sort everything in alphabetical order, with Welcome page first
 export const parameters = {
   options: {
     storySort: {
       method: 'alphabetical',
-      order: ['Welcome', 'Components'], 
+      order: ['Welcome'], 
     },
   },
 };

--- a/stories/10-EditableSlider.stories.jsx
+++ b/stories/10-EditableSlider.stories.jsx
@@ -5,7 +5,7 @@ import { MLEditableSlider } from '@marklogic/design-system'
 import mdx from './10-EditableSlider.mdx'
 
 export default {
-  title: 'Data Entry/MLEditableSlider',
+  title: 'EditableSlider',
   decorators: [withKnobs],
   parameters: {
     fileName: '10-EditableSlider.stories.jsx',

--- a/stories/11-Table.stories.jsx
+++ b/stories/11-Table.stories.jsx
@@ -7,7 +7,7 @@ import cloneDeep from 'lodash-es/cloneDeep'
 import mdx from './11-Table.mdx'
 
 export default {
-  title: 'Data Display/MLTable',
+  title: 'Table',
   decorators: [withKnobs],
   parameters: {
     fileName: '11-Table.stories.jsx',

--- a/stories/13-Header.stories.jsx
+++ b/stories/13-Header.stories.jsx
@@ -9,7 +9,7 @@ import { withKnobs, text } from '@storybook/addon-knobs'
 import mdx from './13-Header.mdx'
 
 export default {
-  title: 'Navigation/MLHeader',
+  title: 'Header',
   component: MLHeader,
   decorators: [withKnobs],
   description: 'Unlike the other components in this library, this component is not based on any Ant component.',

--- a/stories/15-Dropdown.stories.jsx
+++ b/stories/15-Dropdown.stories.jsx
@@ -7,7 +7,7 @@ import UserOutlined from '../src/MLIcon/UserOutlined'
 import mdx from './15-Dropdown.mdx'
 
 export default {
-  title: 'Navigation/MLDropdown',
+  title: 'Dropdown',
   decorators: [withKnobs],
   parameters: {
     fileName: '15-Dropdown.stories.jsx',

--- a/stories/15-Dropdown.stories.jsx
+++ b/stories/15-Dropdown.stories.jsx
@@ -7,7 +7,7 @@ import UserOutlined from '../src/MLIcon/UserOutlined'
 import mdx from './15-Dropdown.mdx'
 
 export default {
-  title: 'Dropdown',
+  title: 'Dropdown (Drop Menu)',
   decorators: [withKnobs],
   parameters: {
     fileName: '15-Dropdown.stories.jsx',

--- a/stories/16-Menu.stories.jsx
+++ b/stories/16-Menu.stories.jsx
@@ -8,7 +8,7 @@ import SettingOutlined from '../src/MLIcon/SettingOutlined'
 import mdx from './16-Menu.mdx'
 
 export default {
-  title: 'Navigation/MLMenu',
+  title: 'MLMenu',
   decorators: [withKnobs],
   parameters: {
     fileName: '16-Menu.stories.jsx',

--- a/stories/16-Menu.stories.jsx
+++ b/stories/16-Menu.stories.jsx
@@ -8,7 +8,7 @@ import SettingOutlined from '../src/MLIcon/SettingOutlined'
 import mdx from './16-Menu.mdx'
 
 export default {
-  title: 'MLMenu',
+  title: 'Menu',
   decorators: [withKnobs],
   parameters: {
     fileName: '16-Menu.stories.jsx',

--- a/stories/17-Select.stories.jsx
+++ b/stories/17-Select.stories.jsx
@@ -7,7 +7,7 @@ import mdx from './17-Select.mdx'
 const { MLOption, MLOptGroup } = MLSelect
 
 export default {
-  title: 'MLSelect',
+  title: 'Select',
   decorators: [withKnobs],
   parameters: {
     fileName: '17-Select.stories.jsx',

--- a/stories/17-Select.stories.jsx
+++ b/stories/17-Select.stories.jsx
@@ -7,7 +7,7 @@ import mdx from './17-Select.mdx'
 const { MLOption, MLOptGroup } = MLSelect
 
 export default {
-  title: 'Data Entry/MLSelect',
+  title: 'MLSelect',
   decorators: [withKnobs],
   parameters: {
     fileName: '17-Select.stories.jsx',

--- a/stories/17-Select.stories.jsx
+++ b/stories/17-Select.stories.jsx
@@ -7,7 +7,7 @@ import mdx from './17-Select.mdx'
 const { MLOption, MLOptGroup } = MLSelect
 
 export default {
-  title: 'Select',
+  title: 'Select (Dropdown)',
   decorators: [withKnobs],
   parameters: {
     fileName: '17-Select.stories.jsx',

--- a/stories/18-Avatar.stories.jsx
+++ b/stories/18-Avatar.stories.jsx
@@ -4,7 +4,7 @@ import { text, withKnobs } from '@storybook/addon-knobs'
 import mdx from './18-Avatar.mdx'
 
 export default {
-  title: 'MLAvatar',
+  title: 'Avatar',
   component: MLAvatar,
   decorators: [withKnobs],
   parameters: {

--- a/stories/18-Avatar.stories.jsx
+++ b/stories/18-Avatar.stories.jsx
@@ -4,7 +4,7 @@ import { text, withKnobs } from '@storybook/addon-knobs'
 import mdx from './18-Avatar.mdx'
 
 export default {
-  title: 'Data Display/MLAvatar',
+  title: 'MLAvatar',
   component: MLAvatar,
   decorators: [withKnobs],
   parameters: {

--- a/stories/19-Icon.stories.jsx
+++ b/stories/19-Icon.stories.jsx
@@ -12,7 +12,7 @@ import { antIconVariants, faIconVariants } from '../src/MLIcon/MLIcon'
 import reduce from 'lodash-es/reduce'
 
 export default {
-  title: 'General/MLIcon',
+  title: 'MLIcon',
   decorators: [withKnobs],
   parameters: {
     fileName: '19-Icon.stories.jsx',

--- a/stories/19-Icon.stories.jsx
+++ b/stories/19-Icon.stories.jsx
@@ -12,7 +12,7 @@ import { antIconVariants, faIconVariants } from '../src/MLIcon/MLIcon'
 import reduce from 'lodash-es/reduce'
 
 export default {
-  title: 'MLIcon',
+  title: 'Icon',
   decorators: [withKnobs],
   parameters: {
     fileName: '19-Icon.stories.jsx',

--- a/stories/2-Button.stories.jsx
+++ b/stories/2-Button.stories.jsx
@@ -5,7 +5,7 @@ import { MLButton } from '@marklogic/design-system'
 import mdx from './2-Button.mdx'
 
 export default {
-  title: 'General/MLButton',
+  title: 'Button',
   decorators: [withKnobs],
   parameters: {
     fileName: '2-Button.stories.jsx',

--- a/stories/20-Collapse.stories.jsx
+++ b/stories/20-Collapse.stories.jsx
@@ -8,7 +8,7 @@ import mdx from './20-Collapse.mdx'
 const { MLPanel } = MLCollapse
 
 export default {
-  title: 'Data Display/MLCollapse',
+  title: 'Collapse (Expand)',
   decorators: [withKnobs],
   parameters: {
     fileName: '20-Collapse.stories.jsx',

--- a/stories/21-Empty.stories.jsx
+++ b/stories/21-Empty.stories.jsx
@@ -5,7 +5,7 @@ import { MLEmpty } from '@marklogic/design-system'
 import mdx from './21-Empty.mdx'
 
 export default {
-  title: 'Data Display/MLEmpty',
+  title: 'Empty',
   decorators: [withKnobs],
   parameters: {
     fileName: '21-Empty.stories.jsx',

--- a/stories/22-Statistic.stories.jsx
+++ b/stories/22-Statistic.stories.jsx
@@ -6,7 +6,7 @@ import LikeOutlined from '../src/MLIcon/LikeOutlined'
 import mdx from './22-Statistic.mdx'
 
 export default {
-  title: 'Data Display/MLStatistic',
+  title: 'Statistic',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/23-Tooltip.stories.jsx
+++ b/stories/23-Tooltip.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './23-Tooltip.mdx'
 
 export default {
-  title: 'Data Display/MLTooltip',
+  title: 'Tooltip',
   decorators: [withKnobs],
   parameters: {
     fileName: '23-Tooltip.stories.jsx',

--- a/stories/24-Alert.stories.jsx
+++ b/stories/24-Alert.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs, text, boolean } from '@storybook/addon-knobs'
 import mdx from './24-Alert.mdx'
 
 export default {
-  title: 'Feedback/MLAlert',
+  title: 'Alert',
   decorators: [withKnobs],
   parameters: {
     fileName: '24-Alert.stories.jsx',

--- a/stories/25-Modal.stories.jsx
+++ b/stories/25-Modal.stories.jsx
@@ -6,7 +6,7 @@ import TrashAltSolid from '../src/MLIcon/TrashAltSolid'
 import mdx from './25-Modal.mdx'
 
 export default {
-  title: 'Feedback/MLModal',
+  title: 'Modal',
   component: MLModal,
   decorators: [withKnobs],
   parameters: {

--- a/stories/26-Result.stories.jsx
+++ b/stories/26-Result.stories.jsx
@@ -6,7 +6,7 @@ import SmileRegular from '../src/MLIcon/SmileRegular'
 import mdx from './26-Result.mdx'
 
 export default {
-  title: 'Feedback/MLResult',
+  title: 'Result',
   decorators: [withKnobs],
   parameters: {
     fileName: '26-Result.stories.jsx',

--- a/stories/27-Spin.stories.jsx
+++ b/stories/27-Spin.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './27-Spin.mdx'
 
 export default {
-  title: 'Feedback/MLSpin',
+  title: 'Spin (Loading)',
   decorators: [withKnobs],
   parameters: {
     fileName: '27-Spin.stories.jsx',

--- a/stories/29-Grid.stories.jsx
+++ b/stories/29-Grid.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './29-Grid.mdx'
 
 export default {
-  title: 'Layout/Grid (MLRow and MLCol)',
+  title: 'Grid (Row and Col)',
   decorators: [withKnobs],
   parameters: {
     fileName: '29-Grid.stories.jsx',

--- a/stories/3-ColorPalette.stories.jsx
+++ b/stories/3-ColorPalette.stories.jsx
@@ -9,7 +9,7 @@ import mdx from './3-ColorPalette.mdx'
 const MLCard = Card
 
 export default {
-  title: 'Styles',
+  title: 'Color Pallete',
   decorators: [withKnobs],
   parameters: {
     fileName: '3-ColorPalette.stories.jsx',

--- a/stories/30-Affix.stories.jsx
+++ b/stories/30-Affix.stories.jsx
@@ -5,7 +5,7 @@ import { MLAffix, MLButton } from '@marklogic/design-system'
 import mdx from './30-Affix.mdx'
 
 export default {
-  title: 'Affix (Anchor)',
+  title: 'Affix',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/30-Affix.stories.jsx
+++ b/stories/30-Affix.stories.jsx
@@ -5,7 +5,7 @@ import { MLAffix, MLButton } from '@marklogic/design-system'
 import mdx from './30-Affix.mdx'
 
 export default {
-  title: 'Navigation/MLAffix',
+  title: 'Affix (Anchor)',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/31-Breadcrumb.stories.jsx
+++ b/stories/31-Breadcrumb.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './31-Breadcrumb.mdx'
 
 export default {
-  title: 'Navigation/MLBreadcrumb',
+  title: 'Breadcrumb',
   decorators: [withKnobs],
   parameters: {
     fileName: '31-Breadcrumb.stories.jsx',

--- a/stories/33-AutoComplete.stories.jsx
+++ b/stories/33-AutoComplete.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './33-AutoComplete.mdx'
 
 export default {
-  title: 'Data Entry/MLAutoComplete',
+  title: 'AutoComplete',
   decorators: [withKnobs],
   parameters: {
     fileName: '33-AutoComplete.stories.jsx',

--- a/stories/34-Cascader.stories.jsx
+++ b/stories/34-Cascader.stories.jsx
@@ -5,7 +5,7 @@ import { MLCascader } from '@marklogic/design-system'
 import mdx from './34-Cascader.mdx'
 
 export default {
-  title: 'Data Entry/MLCascader',
+  title: 'Cascader',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/34-Cascader.stories.jsx
+++ b/stories/34-Cascader.stories.jsx
@@ -5,7 +5,7 @@ import { MLCascader } from '@marklogic/design-system'
 import mdx from './34-Cascader.mdx'
 
 export default {
-  title: 'Cascader',
+  title: 'Cascader (Pull-Right Menu)',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/36-Form.stories.jsx
+++ b/stories/36-Form.stories.jsx
@@ -38,7 +38,7 @@ import {
 } from 'antd'
 
 export default {
-  title: 'Data Entry/MLForm',
+  title: 'Form',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/37-InputNumber.stories.jsx
+++ b/stories/37-InputNumber.stories.jsx
@@ -5,7 +5,7 @@ import { MLInputNumber } from '@marklogic/design-system'
 import mdx from './37-InputNumber.mdx'
 
 export default {
-  title: 'Data Entry/MLInputNumber',
+  title: 'InputNumber',
   decorators: [withKnobs],
   parameters: {
     fileName: '37-InputNumber.stories.jsx',

--- a/stories/38-Mentions.stories.jsx
+++ b/stories/38-Mentions.stories.jsx
@@ -6,7 +6,7 @@ import mdx from './38-Mentions.mdx'
 const { MLOption } = MLMentions
 
 export default {
-  title: 'Mentions',
+  title: 'Mentions (Tag)',
   decorators: [withKnobs],
   parameters: {
     fileName: '38-Mentions.stories.jsx',

--- a/stories/38-Mentions.stories.jsx
+++ b/stories/38-Mentions.stories.jsx
@@ -6,7 +6,7 @@ import mdx from './38-Mentions.mdx'
 const { MLOption } = MLMentions
 
 export default {
-  title: 'Data Entry/MLMentions',
+  title: 'Mentions',
   decorators: [withKnobs],
   parameters: {
     fileName: '38-Mentions.stories.jsx',

--- a/stories/39-Rate.stories.jsx
+++ b/stories/39-Rate.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './39-Rate.mdx'
 
 export default {
-  title: 'Data Entry/MLRate',
+  title: 'Rate',
   decorators: [withKnobs],
   parameters: {
     fileName: '39-Rate.stories.jsx',

--- a/stories/4-Typography.stories.jsx
+++ b/stories/4-Typography.stories.jsx
@@ -5,7 +5,7 @@ import { MLTypography } from '@marklogic/design-system'
 import mdx from './4-Typography.mdx'
 
 export default {
-  title: 'General/MLTypography',
+  title: 'Typography',
   decorators: [withKnobs],
   parameters: {
     fileName: '4-Typography.stories.jsx',

--- a/stories/40-Radio.stories.jsx
+++ b/stories/40-Radio.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs, boolean, text, array, number } from '@storybook/addon-knobs'
 import mdx from './40-Radio.mdx'
 
 export default {
-  title: 'Data Entry/MLRadio',
+  title: 'Radio',
   decorators: [withKnobs],
   parameters: {
     fileName: '40-Radio.stories.jsx',

--- a/stories/41-Switch.stories.jsx
+++ b/stories/41-Switch.stories.jsx
@@ -6,7 +6,7 @@ import mdx from './41-Switch.mdx'
 
 export default {
   component: MLSwitch,
-  title: 'Switch',
+  title: 'Switch (Toggle)',
   decorators: [withKnobs],
   parameters: {
     fileName: '41-Switch.stories.jsx',

--- a/stories/41-Switch.stories.jsx
+++ b/stories/41-Switch.stories.jsx
@@ -6,7 +6,7 @@ import mdx from './41-Switch.mdx'
 
 export default {
   component: MLSwitch,
-  title: 'Data Entry/MLSwitch',
+  title: 'Switch',
   decorators: [withKnobs],
   parameters: {
     fileName: '41-Switch.stories.jsx',

--- a/stories/42-Slider.stories.jsx
+++ b/stories/42-Slider.stories.jsx
@@ -5,7 +5,7 @@ import { MLSlider } from '@marklogic/design-system'
 import mdx from './42-Slider.mdx'
 
 export default {
-  title: 'Data Entry/MLSlider',
+  title: 'Slider',
   decorators: [withKnobs],
   parameters: {
     fileName: '42-Slider.stories.jsx',

--- a/stories/43-TreeSelect.stories.jsx
+++ b/stories/43-TreeSelect.stories.jsx
@@ -5,7 +5,7 @@ import { MLTreeSelect } from '@marklogic/design-system'
 import mdx from './43-TreeSelect.mdx'
 
 export default {
-  title: 'Data Entry/MLTreeSelect',
+  title: 'TreeSelect',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/46-Upload.stories.jsx
+++ b/stories/46-Upload.stories.jsx
@@ -6,7 +6,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './46-Upload.mdx'
 
 export default {
-  title: 'Data Entry/MLUpload',
+  title: 'Upload',
   decorators: [withKnobs],
   parameters: {
     fileName: '46-Upload.stories.jsx',

--- a/stories/47-Badge.stories.jsx
+++ b/stories/47-Badge.stories.jsx
@@ -7,7 +7,7 @@ import NotificationOutlined from '../src/MLIcon/NotificationOutlined'
 import mdx from './47-Badge.mdx'
 
 export default {
-  title: 'Data Display/MLBadge',
+  title: 'Badge',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/49-Carousel.stories.jsx
+++ b/stories/49-Carousel.stories.jsx
@@ -6,7 +6,7 @@ import './49-Carousel.less'
 import mdx from './49-Carousel.mdx'
 
 export default {
-  title: 'Data Display/MLCarousel',
+  title: 'Carousel',
   decorators: [withKnobs],
   parameters: {
     fileName: '49-Carousel.stories.jsx',

--- a/stories/5-PageHeader.stories.jsx
+++ b/stories/5-PageHeader.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './5-PageHeader.mdx'
 
 export default {
-  title: 'Navigation/MLPageHeader',
+  title: 'PageHeader',
   decorators: [withKnobs],
   parameters: {
     fileName: '5-PageHeader.stories.jsx',

--- a/stories/50-Card.stories.jsx
+++ b/stories/50-Card.stories.jsx
@@ -13,7 +13,7 @@ import { withKnobs, radios, text, boolean } from '@storybook/addon-knobs'
 import mdx from './50-Card.mdx'
 
 export default {
-  title: 'Data Display/MLCard',
+  title: 'Card',
   decorators: [withKnobs],
   parameters: {
     fileName: '50-Card.stories.jsx',

--- a/stories/52-Descriptions.stories.jsx
+++ b/stories/52-Descriptions.stories.jsx
@@ -5,7 +5,7 @@ import { MLDescriptions } from '@marklogic/design-system'
 import mdx from './52-Descriptions.mdx'
 
 export default {
-  title: 'Data Display/MLDescriptions',
+  title: 'Descriptions',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/53-List.stories.jsx
+++ b/stories/53-List.stories.jsx
@@ -11,7 +11,7 @@ import {
 const MLText = MLTypography.Text
 
 export default {
-  title: 'Data Display/MLList',
+  title: 'List',
   decorators: [withKnobs],
   parameters: {
     fileName: '53-List.stories.jsx',

--- a/stories/54-Popover.stories.jsx
+++ b/stories/54-Popover.stories.jsx
@@ -6,7 +6,7 @@ import './54-Popover.less'
 import mdx from './54-Popover.mdx'
 
 export default {
-  title: 'Data Display/MLPopover',
+  title: 'Popover',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/55-Tree.stories.jsx
+++ b/stories/55-Tree.stories.jsx
@@ -5,7 +5,7 @@ import { DownOutlined } from '../src/MLIcon'
 import mdx from './55-Tree.mdx'
 
 export default {
-  title: 'Data Display/MLTree',
+  title: 'Tree',
   component: MLTree,
   decorators: [withKnobs],
   parameters: {

--- a/stories/56-Timeline.stories.jsx
+++ b/stories/56-Timeline.stories.jsx
@@ -5,7 +5,7 @@ import { MLTimeline } from '@marklogic/design-system'
 import mdx from './56-Timeline.mdx'
 
 export default {
-  title: 'Data Display/MLTimeline',
+  title: 'Timeline',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/57-Tag.stories.jsx
+++ b/stories/57-Tag.stories.jsx
@@ -7,7 +7,7 @@ import mdx from './57-Tag.mdx'
 const { MLCheckableTag } = MLTag
 
 export default {
-  title: 'Data Display/MLTag',
+  title: 'Tag',
   decorators: [withKnobs],
   parameters: {
     fileName: '57-Tag.stories.jsx',

--- a/stories/58-Tabs.stories.jsx
+++ b/stories/58-Tabs.stories.jsx
@@ -5,7 +5,7 @@ import { MLTabs } from '@marklogic/design-system'
 import mdx from './58-Tabs.mdx'
 
 export default {
-  title: 'Data Display/MLTabs',
+  title: 'Tabs',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/59-Drawer.stories.jsx
+++ b/stories/59-Drawer.stories.jsx
@@ -5,7 +5,7 @@ import { MLDrawer, MLButton } from '@marklogic/design-system'
 import mdx from './59-Drawer.mdx'
 
 export default {
-  title: 'Feedback/MLDrawer',
+  title: 'Drawer',
   decorators: [withKnobs],
   parameters: {
     fileName: '59-Drawer.stories.jsx',

--- a/stories/59-Drawer.stories.jsx
+++ b/stories/59-Drawer.stories.jsx
@@ -5,7 +5,7 @@ import { MLDrawer, MLButton } from '@marklogic/design-system'
 import mdx from './59-Drawer.mdx'
 
 export default {
-  title: 'Drawer',
+  title: 'Drawer (Panel)',
   decorators: [withKnobs],
   parameters: {
     fileName: '59-Drawer.stories.jsx',

--- a/stories/6-Pagination.stories.jsx
+++ b/stories/6-Pagination.stories.jsx
@@ -5,7 +5,7 @@ import { MLPagination } from '@marklogic/design-system'
 import mdx from './6-Pagination.mdx'
 
 export default {
-  title: 'Navigation/MLPagination',
+  title: 'Pagination',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/60-message.stories.jsx
+++ b/stories/60-message.stories.jsx
@@ -6,7 +6,7 @@ import SmileOutlined from '@ant-design/icons/lib/icons/SmileOutlined'
 import mdx from './60-message.mdx'
 
 export default {
-  title: 'Feedback/mlmessage',
+  title: 'Message',
   decorators: [withKnobs],
   parameters: {
     fileName: '60-message.stories.jsx',

--- a/stories/62-Progress.stories.jsx
+++ b/stories/62-Progress.stories.jsx
@@ -5,7 +5,7 @@ import mdx from './62-Progress.mdx'
 
 export default {
   component: MLProgress,
-  title: 'Feedback/MLProgress',
+  title: 'Progress Bar',
   decorators: [withKnobs],
   parameters: {
     fileName: '62-Progress.stories.jsx',

--- a/stories/63-Popconfirm.stories.jsx
+++ b/stories/63-Popconfirm.stories.jsx
@@ -6,7 +6,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './63-Popconfirm.mdx'
 
 export default {
-  title: 'Feedback/MLPopconfirm',
+  title: 'Popconfirm',
   decorators: [withKnobs],
   parameters: {
     fileName: '63-Popconfirm.stories.jsx',

--- a/stories/64-Skeleton.stories.jsx
+++ b/stories/64-Skeleton.stories.jsx
@@ -5,7 +5,7 @@ import { MLSkeleton } from '@marklogic/design-system'
 import mdx from './64-Skeleton.mdx'
 
 export default {
-  title: 'Feedback/MLSkeleton',
+  title: 'Skeleton',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/65-Anchor.stories.jsx
+++ b/stories/65-Anchor.stories.jsx
@@ -5,7 +5,7 @@ import { MLAnchor } from '@marklogic/design-system'
 import mdx from './65-Anchor.mdx'
 
 export default {
-  title: 'Other/MLAnchor',
+  title: 'Anchor',
   decorators: [withKnobs],
   parameters: {
     docs: {

--- a/stories/67-ConfigProvider.stories.jsx
+++ b/stories/67-ConfigProvider.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs, text } from '@storybook/addon-knobs'
 import mdx from './67-ConfigProvider.mdx'
 
 export default {
-  title: 'Other/MLConfigProvider',
+  title: 'ConfigProvider',
   decorators: [withKnobs],
   parameters: {
     fileName: '67-ConfigProvider.stories.jsx',

--- a/stories/68-Divider.stories.jsx
+++ b/stories/68-Divider.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './68-Divider.mdx'
 
 export default {
-  title: 'Other/MLDivider',
+  title: 'Divider',
   decorators: [withKnobs],
   parameters: {
     fileName: '68-Divider.stories.jsx',

--- a/stories/7-Checkbox.stories.jsx
+++ b/stories/7-Checkbox.stories.jsx
@@ -5,7 +5,7 @@ import { withKnobs } from '@storybook/addon-knobs'
 import mdx from './7-Checkbox.mdx'
 
 export default {
-  title: 'Data Entry/MLCheckbox',
+  title: 'Checkbox',
   decorators: [withKnobs],
   parameters: {
     fileName: '7-Checkbox.stories.jsx',

--- a/stories/73-DatePicker.stories.jsx
+++ b/stories/73-DatePicker.stories.jsx
@@ -6,7 +6,7 @@ import mdx from './73-DatePicker.mdx'
 const { MLRangePicker } = MLDatePicker
 
 export default {
-  title: 'Data Entry/MLDatePicker',
+  title: 'DatePicker',
   decorators: [withKnobs],
   parameters: {
     fileName: '73-DatePicker.stories.jsx',

--- a/stories/75-Layout.stories.jsx
+++ b/stories/75-Layout.stories.jsx
@@ -6,7 +6,7 @@ import mdx from './75-Layout.mdx'
 const { MLHeader, MLFooter, MLSider, MLContent } = MLLayout
 
 export default {
-  title: 'Layout/MLLayout',
+  title: 'Layout',
   decorators: [withKnobs],
   parameters: {
     fileName: '75-Layout.stories.jsx',

--- a/stories/8-Input.stories.jsx
+++ b/stories/8-Input.stories.jsx
@@ -13,7 +13,7 @@ import {
 import mdx from './8-Input.mdx'
 
 export default {
-  title: 'Data Entry/MLInput',
+  title: 'Input',
   decorators: [withKnobs],
   parameters: {
     fileName: '8-Input.stories.jsx',


### PR DESCRIPTION
Removed 'ML' from titles and removed folder organization in side nav to a single list. Organized all components in alphabetical order, with the exception of Welcome page first.