### PR TITLE
Lock font awesome brand version to 5.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
   "dependencies": {
     "@ant-design/icons": "^4.1.0",
     "@fortawesome/fontawesome-svg-core": "^1.2.25",
-    "@fortawesome/free-brands-svg-icons": "^5.13.0",
+    "@fortawesome/free-brands-svg-icons": "5.13.0",
     "@fortawesome/free-regular-svg-icons": "5.13.0",
     "@fortawesome/free-solid-svg-icons": "5.13.0",
     "@fortawesome/react-fontawesome": "^0.1.7",


### PR DESCRIPTION
Lock font awesome brand version to 5.13.0
npm install the actual version 5.15.4 and breaks UI test because that version don't have an Adobe icon and design-system try to access on undefined object property trying working with it.